### PR TITLE
Add timeouts and progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ environment):
    ```
 
 The script crawls pages starting from `https://www.chandamama.in/story/` looking
-for links containing `englishview.php`. Only files for the requested year are
-downloaded and placed in the `chandamama_books_<year>` directory.
+for links containing `englishview.php`. Only English PDF files for the
+requested year are downloaded and placed in the
+`chandamama_books_<year>` directory. Each request uses a two minute timeout and
+the script prints progress with an estimated download time for each file.
 
 **Note:** This repository cannot verify the availability or legality of the
 content. Ensure that downloading these files complies with the website's terms


### PR DESCRIPTION
## Summary
- document english-only downloads and new progress output
- increase request timeout to 2 minutes
- log estimated download time using response headers

## Testing
- `python -m py_compile download_chandamama_books.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f48afccc8331a0f0453b191159d5