### PR TITLE
Improve crawler logging and link filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The script crawls pages starting from `https://www.chandamama.in/story/` looking
 for links containing `englishview.php`. Only English PDF files for the
 requested year are downloaded and placed in the
 `chandamama_books_<year>` directory. Each request uses a two minute timeout and
-the script prints progress with an estimated download time for each file.
+progress is logged to the console with an estimated download time for each
+file.
 
 **Note:** This repository cannot verify the availability or legality of the
 content. Ensure that downloading these files complies with the website's terms


### PR DESCRIPTION
## Summary
- add logging module and configure console output
- skip Hindi pages and story links for other years
- only record PDF links from English resources
- log download progress instead of printing
- update documentation about console logging

## Testing
- `python -m py_compile download_chandamama_books.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f6ca05a88331a03ef5fd2201ef1d